### PR TITLE
20 implement field descriptions and help buttons on fields

### DIFF
--- a/src/components/help-tooltip.tsx
+++ b/src/components/help-tooltip.tsx
@@ -1,0 +1,31 @@
+import Question from '@material-design-icons/svg/outlined/question_mark.svg';
+import React from 'react';
+import Button from './button';
+import Tooltip, { TooltipProps } from './tooltip';
+
+type HelpTooltipProps = {
+    readonly onClick?: React.MouseEventHandler<HTMLButtonElement>;
+} & TooltipProps;
+
+function HelpTooltip(props: HelpTooltipProps) {
+	const {ariaTooltipProps, state, children, onClick} = props;
+
+	return (
+		<Tooltip state={state} ariaTooltipProps={ariaTooltipProps}>
+			<div className='flex'>
+				<Question className='mt-1' width='148'/>
+				<div>
+					{children}
+                    {onClick && 
+                        <div className='flex justify-end mr-1 mt-2'>
+                            <Button variant='secondary'>Ayuda</Button>
+                        </div>
+                    }
+				</div>
+			</div>
+		</Tooltip>
+
+	);
+}
+
+export default HelpTooltip;

--- a/src/components/help-tooltip.tsx
+++ b/src/components/help-tooltip.tsx
@@ -1,10 +1,10 @@
 import Question from '@material-design-icons/svg/outlined/question_mark.svg';
 import React from 'react';
-import Button from './button';
-import Tooltip, { TooltipProps } from './tooltip';
+import Button from './button.tsx';
+import Tooltip, {type TooltipProps} from './tooltip.tsx';
 
 type HelpTooltipProps = {
-    readonly onClick?: React.MouseEventHandler<HTMLButtonElement>;
+	readonly onClick?: React.MouseEventHandler<HTMLButtonElement>;
 } & TooltipProps;
 
 function HelpTooltip(props: HelpTooltipProps) {
@@ -16,11 +16,8 @@ function HelpTooltip(props: HelpTooltipProps) {
 				<Question className='mt-1' width='148'/>
 				<div>
 					{children}
-                    {onClick && 
-                        <div className='flex justify-end mr-1 mt-2'>
-                            <Button variant='secondary'>Ayuda</Button>
-                        </div>
-                    }
+					{onClick
+                        && <div className='flex justify-end mr-1 mt-2'> <Button variant='secondary'>Ayuda</Button> </div>}
 				</div>
 			</div>
 		</Tooltip>

--- a/src/components/tooltip-button-trigger.tsx
+++ b/src/components/tooltip-button-trigger.tsx
@@ -1,36 +1,36 @@
-import React, { ForwardedRef, forwardRef } from 'react';
-import { mergeProps, useTooltipTrigger, type TooltipTriggerProps } from 'react-aria';
-import { useTooltipTriggerState } from 'react-stately';
-import Button, { type ButtonProps } from './button.tsx';
-import Tooltip from './tooltip';
-import { useObjectRef } from '@react-aria/utils';
+import {useObjectRef} from '@react-aria/utils';
+import React, {forwardRef, type ForwardedRef} from 'react';
+import {mergeProps, useTooltipTrigger, type TooltipTriggerProps} from 'react-aria';
+import {useTooltipTriggerState} from 'react-stately';
+import Button, {type ButtonProps} from './button.tsx';
+import Tooltip from './tooltip.tsx';
 
 type TooltipButtonProps = {
-  tooltipTriggerProps: TooltipTriggerProps,
-  children: React.ReactNode,
-  tooltip: React.ReactNode,
+	readonly tooltipTriggerProps: TooltipTriggerProps;
+	readonly children: React.ReactNode;
+	readonly tooltip: React.ReactNode;
 } & ButtonProps;
 
 const TooltipButton = forwardRef((props: TooltipButtonProps, ref: ForwardedRef<HTMLButtonElement>) => {
-  const { tooltipTriggerProps, children, tooltip } = props;
-  const state = useTooltipTriggerState(tooltipTriggerProps);
-  const buttonRef = useObjectRef(ref);
+	const {tooltipTriggerProps, children, tooltip} = props;
+	const state = useTooltipTriggerState(tooltipTriggerProps);
+	const buttonRef = useObjectRef(ref);
 
-  const { triggerProps, tooltipProps } = useTooltipTrigger(tooltipTriggerProps, state, buttonRef);
+	const {triggerProps, tooltipProps} = useTooltipTrigger(tooltipTriggerProps, state, buttonRef);
 
-  return (
-    <span style={{ position: 'relative' }}>
-      <Button
-        {...mergeProps(triggerProps, props)}
-        ref={ref}
-      >
-        {children}
-      </Button>
-      {state.isOpen && (
-        <Tooltip state={state} ariaTooltipProps={tooltipProps}>{tooltip}</Tooltip>
-      )}
-    </span>
-  );
+	return (
+		<span style={{position: 'relative'}}>
+			<Button
+				{...mergeProps(triggerProps, props)}
+				ref={ref}
+			>
+				{children}
+			</Button>
+			{state.isOpen && (
+				<Tooltip state={state} ariaTooltipProps={tooltipProps}>{tooltip}</Tooltip>
+			)}
+		</span>
+	);
 });
 
 export default TooltipButton;

--- a/src/components/tooltip-button-trigger.tsx
+++ b/src/components/tooltip-button-trigger.tsx
@@ -1,0 +1,36 @@
+import React, { ForwardedRef, forwardRef } from 'react';
+import { mergeProps, useTooltipTrigger, type TooltipTriggerProps } from 'react-aria';
+import { useTooltipTriggerState } from 'react-stately';
+import Button, { type ButtonProps } from './button.tsx';
+import Tooltip from './tooltip';
+import { useObjectRef } from '@react-aria/utils';
+
+type TooltipButtonProps = {
+  tooltipTriggerProps: TooltipTriggerProps,
+  children: React.ReactNode,
+  tooltip: React.ReactNode,
+} & ButtonProps;
+
+const TooltipButton = forwardRef((props: TooltipButtonProps, ref: ForwardedRef<HTMLButtonElement>) => {
+  const { tooltipTriggerProps, children, tooltip } = props;
+  const state = useTooltipTriggerState(tooltipTriggerProps);
+  const buttonRef = useObjectRef(ref);
+
+  const { triggerProps, tooltipProps } = useTooltipTrigger(tooltipTriggerProps, state, buttonRef);
+
+  return (
+    <span style={{ position: 'relative' }}>
+      <Button
+        {...mergeProps(triggerProps, props)}
+        ref={ref}
+      >
+        {children}
+      </Button>
+      {state.isOpen && (
+        <Tooltip state={state} ariaTooltipProps={tooltipProps}>{tooltip}</Tooltip>
+      )}
+    </span>
+  );
+});
+
+export default TooltipButton;

--- a/src/components/tooltip-button-trigger.tsx
+++ b/src/components/tooltip-button-trigger.tsx
@@ -2,17 +2,19 @@ import {useObjectRef} from '@react-aria/utils';
 import React, {forwardRef, type ForwardedRef} from 'react';
 import {mergeProps, useTooltipTrigger, type TooltipTriggerProps} from 'react-aria';
 import {useTooltipTriggerState} from 'react-stately';
-import Button, {type ButtonProps} from './button.tsx';
-import Tooltip from './tooltip.tsx';
+import type {ButtonProps} from './button.tsx';
+import HelpTooltip from './help-tooltip.tsx';
 
 type TooltipButtonProps = {
 	readonly tooltipTriggerProps: TooltipTriggerProps;
 	readonly children: React.ReactNode;
 	readonly tooltip: React.ReactNode;
+	readonly onClick?: React.MouseEventHandler<HTMLButtonElement>;
+	readonly onClickAyuda?: React.MouseEventHandler<HTMLButtonElement>;
 } & ButtonProps;
 
 const TooltipButton = forwardRef((props: TooltipButtonProps, ref: ForwardedRef<HTMLButtonElement>) => {
-	const {tooltipTriggerProps, children, tooltip} = props;
+	const {tooltipTriggerProps, children, tooltip, onClick, onClickAyuda} = props;
 	const state = useTooltipTriggerState(tooltipTriggerProps);
 	const buttonRef = useObjectRef(ref);
 
@@ -20,14 +22,9 @@ const TooltipButton = forwardRef((props: TooltipButtonProps, ref: ForwardedRef<H
 
 	return (
 		<span style={{position: 'relative'}}>
-			<Button
-				{...mergeProps(triggerProps, props)}
-				ref={ref}
-			>
-				{children}
-			</Button>
+			<button {...mergeProps(triggerProps, props)} ref={ref} onClick={onClick}>{children}</button>
 			{state.isOpen && (
-				<Tooltip state={state} ariaTooltipProps={tooltipProps}>{tooltip}</Tooltip>
+				<HelpTooltip state={state} ariaTooltipProps={tooltipProps} onClick={onClickAyuda}>{tooltip}</HelpTooltip>
 			)}
 		</span>
 	);

--- a/src/components/tooltip.tsx
+++ b/src/components/tooltip.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {mergeProps, useTooltip, type AriaTooltipProps} from 'react-aria';
 import type {TooltipTriggerState} from 'react-stately';
 
-type TooltipProps = {
+export type TooltipProps = {
 	readonly ariaTooltipProps: AriaTooltipProps;
 	readonly children: React.ReactNode;
 	readonly state?: TooltipTriggerState;
@@ -18,7 +18,6 @@ function Tooltip(props: TooltipProps) {
 				position: 'absolute',
 				left: '5px',
 				top: '100%',
-				maxWidth: 150,
 				marginTop: '10px',
 				backgroundColor: 'white',
 				color: 'black',
@@ -26,6 +25,7 @@ function Tooltip(props: TooltipProps) {
 				border: '1px solid gray',
 			}}
 			{...mergeProps(ariaTooltipProps, tooltipProps)}
+			className='bg-stone-900 border border-stone-500 p-1 rounded overflow-y-scroll scroll-smooth scrollbar-thumb-rounded scrollbar-track-transparent scrollbar-thin scrollbar-thumb-stone-50'
 		>
 			{children}
 		</span>

--- a/src/components/tooltip.tsx
+++ b/src/components/tooltip.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { mergeProps, useTooltip, type AriaTooltipProps } from 'react-aria';
+import type { TooltipTriggerState } from 'react-stately';
+
+type TooltipProps = {
+	ariaTooltipProps: AriaTooltipProps, 
+	children: React.ReactNode,
+	state?: TooltipTriggerState
+}
+
+const Tooltip = (props: TooltipProps) => {
+	const { ariaTooltipProps, state, children } = props
+	const { tooltipProps } = useTooltip(ariaTooltipProps, state);
+
+	return (
+	<span
+		style={{
+		position: 'absolute',
+		left: '5px',
+		top: '100%',
+		maxWidth: 150,
+		marginTop: '10px',
+		backgroundColor: 'white',
+		color: 'black',
+		padding: '5px',
+		border: '1px solid gray'
+		}}
+		{...mergeProps(ariaTooltipProps, tooltipProps)}
+	>
+		{children}
+	</span>
+	);
+}
+
+export default Tooltip;

--- a/src/components/tooltip.tsx
+++ b/src/components/tooltip.tsx
@@ -1,34 +1,34 @@
 import React from 'react';
-import { mergeProps, useTooltip, type AriaTooltipProps } from 'react-aria';
-import type { TooltipTriggerState } from 'react-stately';
+import {mergeProps, useTooltip, type AriaTooltipProps} from 'react-aria';
+import type {TooltipTriggerState} from 'react-stately';
 
 type TooltipProps = {
-	ariaTooltipProps: AriaTooltipProps, 
-	children: React.ReactNode,
-	state?: TooltipTriggerState
-}
+	readonly ariaTooltipProps: AriaTooltipProps;
+	readonly children: React.ReactNode;
+	readonly state?: TooltipTriggerState;
+};
 
-const Tooltip = (props: TooltipProps) => {
-	const { ariaTooltipProps, state, children } = props
-	const { tooltipProps } = useTooltip(ariaTooltipProps, state);
+function Tooltip(props: TooltipProps) {
+	const {ariaTooltipProps, state, children} = props;
+	const {tooltipProps} = useTooltip(ariaTooltipProps, state);
 
 	return (
-	<span
-		style={{
-		position: 'absolute',
-		left: '5px',
-		top: '100%',
-		maxWidth: 150,
-		marginTop: '10px',
-		backgroundColor: 'white',
-		color: 'black',
-		padding: '5px',
-		border: '1px solid gray'
-		}}
-		{...mergeProps(ariaTooltipProps, tooltipProps)}
-	>
-		{children}
-	</span>
+		<span
+			style={{
+				position: 'absolute',
+				left: '5px',
+				top: '100%',
+				maxWidth: 150,
+				marginTop: '10px',
+				backgroundColor: 'white',
+				color: 'black',
+				padding: '5px',
+				border: '1px solid gray',
+			}}
+			{...mergeProps(ariaTooltipProps, tooltipProps)}
+		>
+			{children}
+		</span>
 	);
 }
 


### PR DESCRIPTION
Implementación del tooltip de ayuda con botón

<img src="https://github.com/Stock44/probono_site/assets/70488844/d03b8157-6649-4bef-8419-c157afb7341e" alt="image" width="250">

- Error: por el momento no se integra bien con el botón personalizado

Implementación para el botón:
```typescript
import TooltipButton from '@/components/tooltip-button-trigger.tsx';

const tooltipRef = React.useRef<HTMLButtonElement>(null);

<TooltipButton
	ref={tooltipRef}
	tooltipTriggerProps={{
		/**
			* Whether the tooltip should be disabled, independent from the trigger.
			*/
		// isDisabled?: boolean,

		/**
			* The delay time for the tooltip to show up. [See guidelines](https://spectrum.adobe.com/page/tooltip/#Immediate-or-delayed-appearance).
			* @default 1500
			*/
		// delay?: number,

		/**
			* The delay time for the tooltip to close. [See guidelines](https://spectrum.adobe.com/page/tooltip/#Warmup-and-cooldown).
			* @default 500
			*/
		// closeDelay?: number,

		/**
			* By default, opens for both focus and hover. Can be made to open only for focus.
			*/
		// trigger?: 'focus'
	}}
	tooltip={
		<div>
			Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna
		</div>
	}
	onClick={() => {}}
	onClickAyuda={() => {}}
>🔍</TooltipButton>
```